### PR TITLE
Make the dependency chain free of native code

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   "build-depends": [
   ],
   "depends": [
-    "Term::termios:ver<0.2>",
+    "Terminal::MakeRaw:ver<1.0.0+>",
     "Terminal::ANSIParser:auth<zef:japhb>:ver<0.0.3+>",
     "Terminal::Capabilities:auth<zef:japhb>:ver<0.0.1+>",
     "Text::MiscUtils:auth<zef:japhb>:ver<0.0.8+>"

--- a/lib/Terminal/LineEditor/RawTerminalInput.rakumod
+++ b/lib/Terminal/LineEditor/RawTerminalInput.rakumod
@@ -1,6 +1,6 @@
 # ABSTRACT: Input widgets for raw terminal text input
 
-use Term::termios;
+use Terminal::MakeRaw;
 use Terminal::ANSIParser;
 use Terminal::LineEditor::DuospaceInput;
 use Terminal::LineEditor::History;
@@ -314,8 +314,8 @@ role Terminal::LineEditor::RawTerminalIO {
 
         if $.input.t && !$!saved-termios {
             my $fd = $.input.native-descriptor;
-            $!saved-termios = Term::termios.new(:$fd).getattr;
-            Term::termios.new(:$fd).getattr.makeraw.setattr(:FLUSH);
+            $!saved-termios = Terminal::MakeRaw::getattr($fd);
+            Terminal::MakeRaw::makeraw($fd, :FLUSH);
 
             $!done ⚛= 0;
             self.start-parser;
@@ -330,7 +330,8 @@ role Terminal::LineEditor::RawTerminalIO {
 
         if $!saved-termios {
             $!done ⚛= 1;
-            $!saved-termios.setattr(:DRAIN);
+            my $fd = $.input.native-descriptor;
+            Terminal::MakeRaw::setattr($fd, $!saved-termios, :DRAIN);
             $!saved-termios = Nil;
             $.output.put('') if $nl;
         }


### PR DESCRIPTION
This means that installing this module won't require a C compiler toolchain anymore.
Do so by replacing Term::termios with Terminal::MakeRaw.

I just now uploaded Terminal::MakeRaw to the ecosystem. So it might take a few minutes for it to become actually available.