### PR TITLE
Move to Terminal-API

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   "build-depends": [
   ],
   "depends": [
-    "Terminal::MakeRaw:ver<1.0.1+>",
+    "Terminal::API:auth<zef:patrickb>:ver<1.0.0>",
     "Terminal::ANSIParser:auth<zef:japhb>:ver<0.0.3+>",
     "Terminal::Capabilities:auth<zef:japhb>:ver<0.0.1+>",
     "Text::MiscUtils:auth<zef:japhb>:ver<0.0.8+>"


### PR DESCRIPTION
This makes this dist work on Windows and also replaces the VT based terminal size detection.

Part of a set of PRs in Terminal-LineEditor, Terminal-Print and Terminal-Widgets.

Don't merge yet, Terminal-API isn't released yet!